### PR TITLE
externpro 26.01.4-13-g85a4aeb sync

### DIFF
--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,0 +1,4 @@
+{
+  "message": "xpro version 8.5.0.4 tag",
+  "tag": "xpv8.5.0.4"
+}

--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,2 +1,0 @@
-tag: xpv8.5.0.3
-message: "xpro version 8.5.0.3 tag"

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,17 +14,18 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/build-linux.yml@26.01.4
+    secrets:
+      automation_token: ${{ secrets.GHCR_TOKEN }}
     with:
-      cmake-workflow-preset: LinuxRelease
-    secrets: inherit
+      cmake_workflow_preset_suffix: Release
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.6
-    with:
-      cmake-workflow-preset: DarwinRelease
+    uses: externpro/externpro/.github/workflows/build-macos.yml@26.01.4
     secrets: inherit
+    with:
+      cmake_workflow_preset_suffix: Release
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.6
-    with:
-      cmake-workflow-preset: WindowsRelease
+    uses: externpro/externpro/.github/workflows/build-windows.yml@26.01.4
     secrets: inherit
+    with:
+      cmake_workflow_preset_suffix: Release

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@26.01.4
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -8,9 +8,9 @@ on:
 jobs:
   tag:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
-    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/tag-release.yml@26.01.4
     with:
       merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
       pr_number: ${{ github.event.pull_request.number }}
     secrets:
-      workflow_write_token: ${{ secrets.XPUPDATE_TOKEN }}
+      automation_token: ${{ secrets.XPRO_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,5 @@
-cmake_minimum_required(VERSION 3.31)
-set(CMAKE_PROJECT_TOP_LEVEL_INCLUDES .devcontainer/cmake/xproinc.cmake)
+cmake_minimum_required(VERSION 4.3)
 project(node-addon-api VERSION 8.5.0)
-set(targetsFile ${PROJECT_NAME}-targets)
-set(lib_name ${PROJECT_NAME})
-xpFindPkg(PKGS nodexp)
-if(DEFINED XP_NAMESPACE)
-  xpExternPackage(NAMESPACE ${XP_NAMESPACE}
-    TARGETS_FILE ${targetsFile} LIBRARIES ${lib_name}
-    BASE v${CMAKE_PROJECT_VERSION} XPDIFF "intro" DEPS nodexp
-    WEB "https://github.com/nodejs/node-addon-api" UPSTREAM "github.com/nodejs/node-addon-api"
-    DESC "Module for using N-API from C++"
-    LICENSE "[MIT](https://github.com/nodejs/node-addon-api/blob/v8.5.0/LICENSE.md 'MIT License')"
-    )
-  set(nameSpace NAMESPACE ${XP_NAMESPACE}::)
-elseif(NOT DEFINED CMAKE_INSTALL_CMAKEDIR)
-  set(CMAKE_INSTALL_CMAKEDIR ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
-endif()
 ########################################
 set(libsrcs
   napi-inl.deprecated.h
@@ -23,13 +7,28 @@ set(libsrcs
   napi.h
   )
 ########################################
+set(lib_name ${PROJECT_NAME})
 add_library(${lib_name} INTERFACE ${libsrcs})
 target_include_directories(${lib_name} INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_compile_definitions(${lib_name} INTERFACE NODE_ADDON_API_DISABLE_DEPRECATED NAPI_CPP_EXCEPTIONS)
+find_package(nodexp REQUIRED)
 target_link_libraries(${lib_name} INTERFACE ${NODEXP_LIBRARIES})
+########################################
+set(targetsFile ${PROJECT_NAME}-targets)
+if(COMMAND xpExternPackage)
+  xpExternPackage(TARGETS_FILE ${targetsFile}
+    LIBRARIES ${lib_name} DEFAULT_TARGETS ${lib_name}
+    BASE v${CMAKE_PROJECT_VERSION} XPDIFF "intro"
+    WEB "https://github.com/nodejs/node-addon-api" UPSTREAM "github.com/nodejs/node-addon-api"
+    DESC "Module for using N-API from C++"
+    LICENSE "[MIT](https://github.com/nodejs/node-addon-api/blob/v8.5.0/LICENSE.md 'MIT License')"
+    )
+elseif(NOT DEFINED CMAKE_INSTALL_CMAKEDIR)
+  set(CMAKE_INSTALL_CMAKEDIR ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+endif()
 ########################################
 install(TARGETS ${lib_name} EXPORT ${targetsFile})
 install(FILES ${libsrcs} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
-install(EXPORT ${targetsFile} DESTINATION ${CMAKE_INSTALL_CMAKEDIR} ${nameSpace})
+install(EXPORT ${targetsFile} DESTINATION ${CMAKE_INSTALL_CMAKEDIR} NAMESPACE ${PROJECT_NAME}::)
 install(FILES CHANGELOG.md LICENSE.md README.md DESTINATION ${CMAKE_INSTALL_DATADIR})
 install(DIRECTORY doc DESTINATION ${CMAKE_INSTALL_DATADIR})

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,6 +3,7 @@
   "include": [
     ".devcontainer/cmake/presets/xpLinuxNinja.json",
     ".devcontainer/cmake/presets/xpDarwinNinja.json",
-    ".devcontainer/cmake/presets/xpWindowsVs2022.json"
+    ".devcontainer/cmake/presets/xpMswVs2022.json",
+    ".devcontainer/cmake/presets/xpMswVs2026.json"
   ]
 }

--- a/CMakePresetsBase.json
+++ b/CMakePresetsBase.json
@@ -6,7 +6,7 @@
       "hidden": true,
       "binaryDir": "${sourceDir}/_bld-${presetName}",
       "cacheVariables": {
-        "XP_NAMESPACE": "xpro"
+        "CMAKE_EXPERIMENTAL_GENERATE_SBOM": "ca494ed3-b261-4205-a01f-603c95e4cae0"
       }
     }
   ],

--- a/xprodeps.md
+++ b/xprodeps.md
@@ -3,7 +3,7 @@
 |project|license [^_l]|description [dependencies]|version|source|diff [^_d]|
 |-------|-------------|--------------------------|-------|------|----------|
 |<a id='node-addon-api' />[node-addon-api](https://github.com/nodejs/node-addon-api)|[MIT](https://github.com/nodejs/node-addon-api/blob/v8.5.0/LICENSE.md 'MIT License')|Module for using N-API from C++ [deps: _nodexp_]| |[upstream](https://github.com/nodejs/node-addon-api 'github.com/nodejs/node-addon-api')|  [intro]|
-|<a id='nodexp' />[nodexp](https://nodejs.org/en/blog/release/v22.19.0/)|[MIT](https://raw.githubusercontent.com/nodejs/node/v22.19.0/LICENSE 'MIT License')|node/npm development platform and runtime executable bundled as externpro devel package to build addons|[xpv22.19.0.3](https://github.com/externpro/nodexp/releases/tag/xpv22.19.0.3 'release')|[repo](https://github.com/externpro/nodexp 'github.com/externpro/nodexp')|[diff](https://github.com/externpro/nodexp/compare/v0...xpv22.19.0.3 'github.com/externpro/nodexp/compare/v0...xpv22.19.0.3') [bin]|
+|<a id='nodexp' />[nodexp](https://nodejs.org/en/blog/release/v22.19.0/)|[MIT](https://raw.githubusercontent.com/nodejs/node/v22.19.0/LICENSE 'MIT License')|node/npm development platform and runtime executable bundled as externpro devel package to build addons|[xpv22.19.0.4](https://github.com/externpro/nodexp/releases/tag/xpv22.19.0.4 'release')|[repo](https://github.com/externpro/nodexp 'github.com/externpro/nodexp')|[diff](https://github.com/externpro/nodexp/compare/v0...xpv22.19.0.4 'github.com/externpro/nodexp/compare/v0...xpv22.19.0.4') [bin]|
 
 ![deps](xprodeps.svg 'dependencies')
 


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01.4-13-g85a4aeb`

## Changes

- Updated `.devcontainer` to externpro `26.01.4-13-g85a4aeb`
- Previous HEAD: `42cddb26ef9a3cb34ab943beebc56719253f03eb`
- New HEAD: `85a4aeb52826b1666e1ee1e2b24a5ff104e87583`
- Updated caller workflows to match templates
- Created `.github/release-tag.json` (tag: `xpv8.5.0.4`)
  - Optional: add the "release:tag" label to trigger tagging, release builds, and draft release notes
- If you add the \"release:tag\" label, the tag will be \`xpv8.5.0.4\`
- Updated dependency files
  - Files:
    - `xprodeps.md`

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.cmake_workflow_preset_suffix` (renamed from `cmake-workflow-preset`)
- 🔧 xpbuild.yml: preserved repo key `jobs.macos.with.cmake_workflow_preset_suffix` (renamed from `cmake-workflow-preset`)
- 🔧 xpbuild.yml: preserved repo key `jobs.windows.with.cmake_workflow_preset_suffix` (renamed from `cmake-workflow-preset`)
- 🔧 workflow_call input renamed (kebab-case → snake_case): `cmake-workflow-preset` -> `cmake_workflow_preset_suffix`
- ✓ xpbuild.yml: Synced from template
- ✓ xprelease.yml: Synced from template
- ✓ xptag.yml: Synced from template

### CMakePresets.json

- Auto-fix: replaced `.devcontainer/cmake/presets/xpWindowsVs2022.json` include and staged `CMakePresets.json`

- CMakePresets.json review needed

---

*This PR was created automatically by GitHub Actions*
